### PR TITLE
ajuste de la ruta para acceder a la ruta desde la variable de entorno.

### DIFF
--- a/clinica-frontend/nginx.conf
+++ b/clinica-frontend/nginx.conf
@@ -9,9 +9,9 @@ server {
     try_files $uri $uri/ /index.html;
   }
 
-  # Proxy a tu API (servicio docker "api")
+  # Proxy API (servicio docker "api/")
   location /api/ {
-    proxy_pass http://api:80/;   # <- coincide con el nombre del servicio del backend en docker-compose
+    proxy_pass http://api:80/;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/clinica-frontend/src/app/service/Auth-Service/Auth.service.ts
+++ b/clinica-frontend/src/app/service/Auth-Service/Auth.service.ts
@@ -14,6 +14,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
+import { urlApiServicio } from '../../components/utilidades/variable-entorno';
 
 // Interfaces
 export interface User {
@@ -33,7 +34,7 @@ export interface LoginResponse {
     providedIn: 'root'
 })
 export class AuthService {
-    private apiUrl = 'http://127.0.0.1:8000/api';
+    private apiUrl = urlApiServicio.apiUrl;
     private tokenKey = 'auth_token';
     private userKey = 'user';
 


### PR DESCRIPTION
existian rutas declaras que no coincidían con las rutas reales, por lo que fue necesario ajustarlas para que reciban por parámetro desde una variable de entorno.