### PR TITLE
Correxion en la migraciones y servicios de los contenedores

### DIFF
--- a/clinica-backend/.docker/entrypoint.sh
+++ b/clinica-backend/.docker/entrypoint.sh
@@ -3,6 +3,10 @@ set -e
 
 cd /var/www
 
+# Copia .env si no existe (útil en despliegues)
+if [ ! -f .env ] && [ -f .env.example ]; then
+  cp .env.example .env
+fi
 
 # Espera a que MySQL acepte conexiones para ejecutar las migraciones
 until php -r "try { new PDO('mysql:host=' . getenv('DB_HOST') . ';port=' . getenv('DB_PORT'), getenv('DB_USERNAME'), getenv('DB_PASSWORD')); } catch (Exception $e) { exit(1);}"; do

--- a/clinica-backend/Dockerfile
+++ b/clinica-backend/Dockerfile
@@ -1,22 +1,32 @@
-FROM php:8.2-fpm-alpine
-
+FROM php:8.2-fpm-alpine AS php
 WORKDIR /var/www
 
-# Paquetes necesarios
-RUN apk add --no-cache git unzip icu-dev libzip-dev oniguruma-dev
-
-# Extensiones PHP
-RUN docker-php-ext-install pdo pdo_mysql intl bcmath zip opcache
+# SO y extensiones necesarias
+RUN apk add --no-cache icu-dev libzip-dev oniguruma-dev git unzip bash nano \
+ && docker-php-ext-configure intl \
+ && docker-php-ext-install -j$(nproc) pdo pdo_mysql intl bcmath zip opcache
 
 # Composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+ENV COMPOSER_ALLOW_SUPERUSER=1
 
-# Copia de código
+# Se copia solo composer.* para cachear vendor
+COPY composer.json composer.lock ./
+
+# Se instalamos dependencias
+RUN composer install \
+    --no-dev --prefer-dist --no-interaction --no-progress --optimize-autoloader \
+    --no-scripts
+
+# Copiamos el proyecto
 COPY . .
 
-# Instalar dependencias de PHP
-RUN composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader \
- && chown -R www-data:www-data storage bootstrap/cache
+# Se ejecuta composer otra vez para que corran los scripts
+RUN composer install \
+    --no-dev --prefer-dist --no-interaction --no-progress --optimize-autoloader
+
+# Permisos
+RUN chown -R www-data:www-data storage bootstrap/cache
 
 # Entrypoint
 COPY .docker/entrypoint.sh /entrypoint.sh

--- a/clinica-backend/database/migrations/2025_05_22_080448_create_especialistas_table.php
+++ b/clinica-backend/database/migrations/2025_05_22_080448_create_especialistas_table.php
@@ -15,7 +15,7 @@ return new class extends Migration {
     {
         Schema::create('especialistas', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained('users')->onDelete('cascade')->index();
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
             $table->string('especialidad')->nullable();
             $table->timestamps();
             $table->softDeletes();

--- a/clinica-backend/database/migrations/2025_05_22_080454_create_pacientes_table.php
+++ b/clinica-backend/database/migrations/2025_05_22_080454_create_pacientes_table.php
@@ -16,7 +16,7 @@ class CreatePacientesTable extends Migration
     {
         Schema::create('pacientes', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained('users')->onDelete('cascade')->index();
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
             $table->string('numero_historial')->unique();
             $table->date('fecha_alta')->nullable();
             $table->date('fecha_baja')->nullable();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   db:
     image: mysql:8.0
@@ -24,7 +22,8 @@ services:
       context: ./clinica-backend
       dockerfile: Dockerfile
       target: php
-    image: clinica/php:dev
+    image: clinicadieteticamv-php
+    pull_policy: build
     container_name: clinica_php
     environment:
       DB_CONNECTION: mysql


### PR DESCRIPTION
Se corrigen las migración para que no indexe los ids y se modifica el orden de ejecución de los servicios para que se instale primeramente el composer y el resto de servicios principales y luego se vuelca  la imagen de Laravel y Angular