### PR TITLE
corrección en el nombre de la tabla 'configuracion'

### DIFF
--- a/clinica-backend/database/seeders/ConfiguracionSeeder.php
+++ b/clinica-backend/database/seeders/ConfiguracionSeeder.php
@@ -13,7 +13,7 @@ class ConfiguracionSeeder extends Seeder
      */
     public function run(): void
     {
-        DB::table('Configuracion')->insert([
+        DB::table('configuracion')->insert([
             [
                 'clave' => 'duracion_cita',
                 'valor' => '30',//tiempo en minutos


### PR DESCRIPTION
Al intentar sembrar datos en la tabla, estaba declarada con la primera letra en mayúscula y daba una inconsitencia