### PR TITLE
Pruebas para comprobar las notificaciones de correo

### DIFF
--- a/server/clinicamv/docker-compose.yml
+++ b/server/clinicamv/docker-compose.yml
@@ -122,7 +122,7 @@ services:
     env_file: [ ./secrets/clinica.env ]
     entrypoint: ["sh","-lc"]
     working_dir: /var/www
-    command: php artisan queue:work --queue=default --sleep=3 --tries=3 --timeout=120
+    command: php artisan queue:work --sleep=3 --tries=3 --timeout=120 # Corre el worker en todas las colas, prueba para ver donde falla
     restart: unless-stopped
     networks: [red-clinicamv]
     volumes:


### PR DESCRIPTION
-Preparamos el worker para que escuche en todas las colas -Se refactoriza el método para cancelar cita, añadiendo una llamada al notify() y agregando registro log, para ver si se ejecuta la notificación